### PR TITLE
parser.hpp: fix build error related to cpp_standard

### DIFF
--- a/include/standardese/parser.hpp
+++ b/include/standardese/parser.hpp
@@ -33,7 +33,7 @@ namespace standardese
 
     struct compile_config
     {
-        standardese::cpp_standard cpp_standard;
+        cpp_standard standard;
         std::vector<std::string> options;
         std::string commands_dir; // if non-empty looks for a compile_commands.json specification
 
@@ -44,10 +44,10 @@ namespace standardese
         static std::string macro_undefinition(std::string s);
 
         compile_config(std::string commands_dir)
-        : cpp_standard(cpp_standard::count), commands_dir(std::move(commands_dir)) {}
+        : standard(cpp_standard::count), commands_dir(std::move(commands_dir)) {}
 
-        compile_config(standardese::cpp_standard s, std::vector<std::string> options = {})
-        : cpp_standard(s), options(std::move(options)) {}
+        compile_config(cpp_standard s, std::vector<std::string> options = {})
+        : standard(s), options(std::move(options)) {}
     };
 
     /// Parser class used for parsing the C++ classes.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -108,8 +108,8 @@ translation_unit parser::parse(const char *path, const compile_config &c) const
             args.push_back(arg.c_str());
     }
 
-    if (c.cpp_standard != cpp_standard::count)
-        args.push_back(standards[int(c.cpp_standard)]);
+    if (c.standard != cpp_standard::count)
+        args.push_back(standards[int(c.standard)]);
 
     args.reserve(args.size() + 2 * c.options.size());
     for (auto& o : c.options)


### PR DESCRIPTION
I wanted to test the new options in this branch but ran into a compilation error with GCC 5.3.1 on Debian unstable saying that cpp_standard was not a class, namespace or enumeration. It seemed to be caused by the fact that the typename was named with the same identifier as the variable.

Feel free to re-rename the variables !