### PR TITLE
Build with Clang on MacOS

### DIFF
--- a/include/standardese/error.hpp
+++ b/include/standardese/error.hpp
@@ -6,6 +6,7 @@
 #define STANDARDESE_ERROR_HPP_INCLUDED
 
 #include <stdexcept>
+#include <string>
 
 #include <clang-c/Index.h>
 

--- a/include/standardese/string.hpp
+++ b/include/standardese/string.hpp
@@ -127,7 +127,7 @@ namespace standardese
             if (type_ == cx_string)
                 clang_disposeString(*static_cast<CXString*>(get_storage()));
             else if (type_ == std_string)
-                static_cast<std::string*>(get_storage())->std::string::~string();
+                static_cast<std::string*>(get_storage())->~basic_string();
         }
 
         std::aligned_storage<(sizeof(std::string) > sizeof(CXString))


### PR DESCRIPTION
With these two small fixes, Standardese now builds on MacOS with the default Clang.

There are still a load of warnings about unused return values, and one of the tests segfaults, but I haven’t looked at this yet because I don’t know if this is unexpected.