### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+
+# Common CMake build output dirs
+build*/
+
+# QtCreator
+CMakelists.txt.user
+
+# CLion
+.idea/
+
+


### PR DESCRIPTION
This adds a .gitignore which is set to ignore any directory
beginning with "build" (commonly used for CMake output), as well
as IDE files created with QtCreator and CLion