### PR TITLE
Fix linking on MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,8 @@ if (MSVC)
         )
 endif()
 
+add_definitions(-DBOOST_ALL_NO_LIB) # Disable auto-link
+
 # subdirectories
 add_subdirectory(src)
 if(STANDARDESE_BUILD_TOOL)

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ If it isn't found, set the CMake variable `LIBCLANG_INCLUDE_DIR` to the folder w
 under a normal (Linux) installation it is `/usr/lib/clang/<version>/include`.
 
 The library requires Boost.Wave and the tool requires Boost.ProgramOptions and Boost.Filesystem, only tested with 1.60.
+By default, Boost libraries are linked dynamically (except for Boost.ProgramOptions which is always linked statically),
+but if you wish to link them statically, just add `-DBoost_USE_STATIC_LIBS=ON` to the cmake command.
 
-Once build simply run `standardese --help` for commandline usage.
+Once built, simply run `standardese --help` for commandline usage.
 
 ## Documentation 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,7 +80,7 @@ target_include_directories(standardese PUBLIC ${LIBCLANG_INCLUDE_DIR})
 target_link_libraries(standardese PUBLIC ${LIBCLANG_LIBRARY})
 
 # link Boost
-find_package(Boost COMPONENTS wave filesystem REQUIRED)
+find_package(Boost COMPONENTS wave filesystem system thread date_time chrono REQUIRED)
 target_include_directories(standardese PUBLIC ${Boost_INCLUDE_DIR})
 target_link_libraries(standardese PUBLIC ${Boost_LIBRARIES})
 

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -11,7 +11,12 @@ target_link_libraries(standardese_tool PUBLIC standardese)
 set_target_properties(standardese_tool PROPERTIES OUTPUT_NAME standardese)
 
 # link Boost
-find_package(Boost COMPONENTS program_options filesystem REQUIRED)
+
+# Force linking to static libraries. Linking Boost.ProgramOptions dynamic library causes link errors
+# See for example http://stackoverflow.com/questions/11235927/link-to-static-boost-lib-with-cmake-and-vs2010-without-automatic-linking.
+set(Boost_USE_STATIC_LIBS ON)
+
+find_package(Boost COMPONENTS program_options REQUIRED)
 target_include_directories(standardese_tool PUBLIC ${Boost_INCLUDE_DIR})
 target_link_libraries(standardese_tool PUBLIC ${Boost_LIBRARIES})
 


### PR DESCRIPTION
Disable Boost auto-link feature on MSVC.
Explicitly link to dependent Boost libraries.
Force static link to Boost.ProgramOptions.