### PR TITLE
Fix MSVC warnings due to Bost.Wave.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,10 @@ install(DIRECTORY ${SPDLOG_INCLUDE_DIR}/spdlog DESTINATION ${include_dest})
 
 if (MSVC)
     add_compile_options(
+        # Disable warnings
         -D_CRT_SECURE_NO_WARNINGS
         -D_SCL_SECURE_NO_WARNINGS
+        /wd4503 # decorated name length exceeded, name was truncated
         )
 endif()
 

--- a/include/standardese/detail/tokenizer.hpp
+++ b/include/standardese/detail/tokenizer.hpp
@@ -8,9 +8,16 @@
 #include <initializer_list>
 #include <string>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4477) // 'sprintf' : format string '%ld' requires an argument of type 'long', but variadic argument 1 has type 'size_t'
+#endif
 #include <boost/wave/cpplexer/cpp_lex_iterator.hpp>
 #include <boost/wave/cpplexer/cpp_lex_token.hpp>
 #include <boost/wave.hpp>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <standardese/detail/sequence_stream.hpp>
 #include <standardese/error.hpp>


### PR DESCRIPTION
Yes, I don't like warnings, and they make the build logs unreadable.