### PR TITLE
class in template parameter

### DIFF
--- a/src/synopsis.cpp
+++ b/src/synopsis.cpp
@@ -405,7 +405,7 @@ namespace
     void do_write_synopsis(const parser& par, code_block_writer& out,
                            const cpp_template_type_parameter& p)
     {
-        out << "typename";
+        out << "class";
         if (p.is_variadic())
             out << " ...";
         if (!p.get_name().empty())
@@ -431,7 +431,7 @@ namespace
             return true;
         });
 
-        out << "> typename";
+        out << "> class";
         if (p.is_variadic())
             out << " ...";
         if (!p.get_name().empty())

--- a/test/synopsis.cpp
+++ b/test/synopsis.cpp
@@ -110,17 +110,17 @@ TEST_CASE("synopsis")
 
 constexpr int a(char& c, int* ptr, ...) noexcept(noexcept(1+1));
 
-template <typename T, template <typename> typename D, int ... I>
+template <class T, template <class> class D, int ... I>
 void b(T t);
 
-template <typename ... T>
+template <class ... T>
 void c(T&&... ts);
 
 int var = 32;
 
 using type = int;
 
-template <typename T>
+template <class T>
 using identity = T;)";
 
         auto tu = parse(p, "synopsis_toplevel", code);


### PR DESCRIPTION
<!--- When initiating a pull request, please use the develop branch as base.
If it is a critical hotfix I'll manually merge it directly onto master.
Please format everything using clang-format. --->
The standard library uses `class` for template type parameters, instead of `typename`. (See [Standard Library Guidelines](https://isocpp.org/std/library-design-guidelines))
I don't know of any instance of template template parameters in the standard library, but I also changed it for those for consistency, because they're only allowed to use `typename` starting in C++17, and because it seems that standardese has no support for C++17 yet, defaulting to C++14.