### PR TITLE
Fixed pessimizing moves.

### DIFF
--- a/src/md_blocks.cpp
+++ b/src/md_blocks.cpp
@@ -201,7 +201,7 @@ const char* md_code_block::get_fence_info() const STANDARDESE_NOEXCEPT
 md_entity_ptr md_code_block::do_clone(const md_entity* parent) const
 {
     assert(parent);
-    return std::move(make(*parent, detail::unescape_code(get_string()).c_str(), get_fence_info()));
+    return make(*parent, detail::unescape_code(get_string()).c_str(), get_fence_info());
 }
 
 md_ptr<md_paragraph> md_paragraph::parse(cmark_node* cur, const md_entity& parent)
@@ -323,5 +323,5 @@ md_ptr<md_thematic_break> md_thematic_break::make(const md_entity& parent)
 md_entity_ptr md_thematic_break::do_clone(const md_entity* parent) const
 {
     assert(parent);
-    return std::move(make(*parent));
+    return make(*parent);
 }

--- a/src/md_inlines.cpp
+++ b/src/md_inlines.cpp
@@ -32,7 +32,7 @@ md_ptr<md_text> md_text::make(const md_entity& parent, const char* text)
 md_entity_ptr md_text::do_clone(const md_entity* parent) const
 {
     assert(parent);
-    return std::move(make(*parent, get_string()));
+    return make(*parent, get_string());
 }
 
 md_ptr<md_soft_break> md_soft_break::parse(cmark_node* cur, const md_entity& parent)
@@ -52,7 +52,7 @@ md_ptr<md_soft_break> md_soft_break::make(const md_entity& parent)
 md_entity_ptr md_soft_break::do_clone(const md_entity* parent) const
 {
     assert(parent);
-    return std::move(make(*parent));
+    return make(*parent);
 }
 
 md_ptr<md_line_break> md_line_break::parse(cmark_node* cur, const md_entity& parent)
@@ -72,7 +72,7 @@ md_ptr<md_line_break> md_line_break::make(const md_entity& parent)
 md_entity_ptr md_line_break::do_clone(const md_entity* parent) const
 {
     assert(parent);
-    return std::move(make(*parent));
+    return make(*parent);
 }
 
 md_ptr<md_code> md_code::parse(cmark_node* cur, const md_entity& parent)
@@ -95,7 +95,7 @@ md_entity_ptr md_code::do_clone(const md_entity* parent) const
 {
     assert(parent);
     auto str = detail::unescape_code(get_string());
-    return std::move(make(*parent, str.c_str()));
+    return make(*parent, str.c_str());
 }
 
 md_ptr<md_emphasis> md_emphasis::parse(cmark_node* cur, const md_entity& parent)


### PR DESCRIPTION
Moving local variables in a return statement prevents copy elision.