### PR TITLE
updated download URL of catch.hpp

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,8 +4,8 @@
 
 # add catch
 if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/catch.hpp)
-    file(DOWNLOAD https://raw.githubusercontent.com/philsquared/Catch/master/single_include/catch.hpp
-            ${CMAKE_CURRENT_BINARY_DIR}/catch.hpp)
+    file(DOWNLOAD https://github.com/catchorg/Catch2/releases/download/v1.12.2/catch.hpp
+      ${CMAKE_CURRENT_BINARY_DIR}/catch.hpp)
 endif()
 
 set(tests


### PR DESCRIPTION
the location of the catch header has changed. Even though the repo is called [catchorg/Catch2](https://github.com/catchorg/Catch2), the header files for catch1 can be obtained from there
